### PR TITLE
feat: atlas-basic module local tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "files.insertFinalNewline": true
-}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+## Instructions on how to run the terraform modules tests
+
+1. The Terraform version should be the latest (i.e. v1.9.0): this is advised because on earlier versions, tests were at beta stage.
+2. Through terminal, set up the following environment variables: 
+    -  `export MONGODB_ATLAS_PUBLIC_KEY="<YOUR_PUBLIC_KEY>"`
+    -  `export MONGODB_ATLAS_PRIVATE_KEY="<YOUR_PRIVATE_KEY>"`
+    -  `export MONGODB_ATLAS_BASE_URL="https://cloud-dev.mongodb.com/"` 
+    -  `export TF_VAR_org_id=<YOUR_ORG_ID>` 
+3. Run from terminal (from repository root) the command `terraform init`
+4. Run from terminal (from repository root) the command `terraform test`

--- a/tests/atlas_basic_complete.tftest.hcl
+++ b/tests/atlas_basic_complete.tftest.hcl
@@ -1,0 +1,78 @@
+provider "mongodbatlas" {
+}
+
+run "generate_random_name" {
+    module {
+        source = "./tests/random_name_generator"
+    }
+}
+
+run "atlas_basic_complete" {
+    command = apply
+
+    module {
+        source = "./"
+    }
+
+    variables {
+        project_name = "test-modules-tf-p-${run.generate_random_name.name_project}"
+        ip_addresses = ["1.2.3.4", "6.7.8.9"]
+        cidr_blocks  = ["10.1.0.0/16", "12.2.0.0/16"]
+        cluster_name  = "AzureCluster"
+        provider_name = "AZURE"
+        region_name   = "US_EAST_2"
+
+        database_users = [
+            {
+            username = "user1"
+            password = "1234"
+            roles = [
+                {
+                    role = "atlasAdmin"
+                    database = "admin"
+                }
+            ]
+            scopes = [
+                {
+                    name = "cluster1"
+                    type = "CLUSTER"
+                }
+            ]
+            }, 
+            {
+                username = "user2", 
+                password = "4321", 
+                roles = [
+                    {
+                        role = "atlasAdmin"
+                        database = "admin"
+                    }
+                ]
+            }
+        ]
+        
+        electable_specs = {
+            instance_size = "M10"
+            node_count = 5
+        }
+        analytics_specs = {
+            instance_size = "M10"
+            node_count = 3
+        }
+    }
+
+    assert {
+        condition = mongodbatlas_database_user.dbuser["user1"].username == "user1"
+        error_message = "Invalid database username"
+    }
+
+    assert {
+        condition = mongodbatlas_database_user.dbuser["user2"].username == "user2"
+        error_message = "Invalid database username"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.name == "AzureCluster"
+        error_message = "Invalid cluster name"
+    }
+}

--- a/tests/atlas_basic_complete.tftest.hcl
+++ b/tests/atlas_basic_complete.tftest.hcl
@@ -2,77 +2,77 @@ provider "mongodbatlas" {
 }
 
 run "generate_random_name" {
-    module {
-        source = "./tests/random_name_generator"
-    }
+  module {
+    source = "./tests/random_name_generator"
+  }
 }
 
 run "atlas_basic_complete" {
-    command = apply
+  command = apply
 
-    module {
-        source = "./"
-    }
+  module {
+    source = "./"
+  }
 
-    variables {
-        project_name = "test-modules-tf-p-${run.generate_random_name.name_project}"
-        ip_addresses = ["1.2.3.4", "6.7.8.9"]
-        cidr_blocks  = ["10.1.0.0/16", "12.2.0.0/16"]
-        cluster_name  = "AzureCluster"
-        provider_name = "AZURE"
-        region_name   = "US_EAST_2"
+  variables {
+    project_name  = "test-modules-tf-p-${run.generate_random_name.name_project}"
+    ip_addresses  = ["1.2.3.4", "6.7.8.9"]
+    cidr_blocks   = ["10.1.0.0/16", "12.2.0.0/16"]
+    cluster_name  = "AzureCluster"
+    provider_name = "AZURE"
+    region_name   = "US_EAST_2"
 
-        database_users = [
-            {
-            username = "user1"
-            password = "1234"
-            roles = [
-                {
-                    role = "atlasAdmin"
-                    database = "admin"
-                }
-            ]
-            scopes = [
-                {
-                    name = "cluster1"
-                    type = "CLUSTER"
-                }
-            ]
-            }, 
-            {
-                username = "user2", 
-                password = "4321", 
-                roles = [
-                    {
-                        role = "atlasAdmin"
-                        database = "admin"
-                    }
-                ]
-            }
+    database_users = [
+      {
+        username = "user1"
+        password = "1234"
+        roles = [
+          {
+            role     = "atlasAdmin"
+            database = "admin"
+          }
         ]
-        
-        electable_specs = {
-            instance_size = "M10"
-            node_count = 5
-        }
-        analytics_specs = {
-            instance_size = "M10"
-            node_count = 3
-        }
-    }
+        scopes = [
+          {
+            name = "cluster1"
+            type = "CLUSTER"
+          }
+        ]
+      },
+      {
+        username = "user2",
+        password = "4321",
+        roles = [
+          {
+            role     = "atlasAdmin"
+            database = "admin"
+          }
+        ]
+      }
+    ]
 
-    assert {
-        condition = mongodbatlas_database_user.dbuser["user1"].username == "user1"
-        error_message = "Invalid database username"
+    electable_specs = {
+      instance_size = "M10"
+      node_count    = 5
     }
+    analytics_specs = {
+      instance_size = "M10"
+      node_count    = 3
+    }
+  }
 
-    assert {
-        condition = mongodbatlas_database_user.dbuser["user2"].username == "user2"
-        error_message = "Invalid database username"
-    }
+  assert {
+    condition     = mongodbatlas_database_user.dbuser["user1"].username == "user1"
+    error_message = "Invalid database username"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.name == "AzureCluster"
-        error_message = "Invalid cluster name"
-    }
+  assert {
+    condition     = mongodbatlas_database_user.dbuser["user2"].username == "user2"
+    error_message = "Invalid database username"
+  }
+
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.name == "AzureCluster"
+    error_message = "Invalid cluster name"
+  }
 }

--- a/tests/atlas_basic_complete.tftest.hcl
+++ b/tests/atlas_basic_complete.tftest.hcl
@@ -75,4 +75,29 @@ run "atlas_basic_complete" {
     condition     = mongodbatlas_advanced_cluster.cluster.name == "AzureCluster"
     error_message = "Invalid cluster name"
   }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["user1"].roles : role if role.role_name == "atlasAdmin"]) > 0
+    error_message = "Invalid user role"
+  }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["user1"].roles : role if role.database_name == "admin"]) > 0
+    error_message = "Invalid user database"
+  }
+
+  assert {
+    condition     = length([for scope in mongodbatlas_database_user.dbuser["user1"].scopes : scope if scope.name == "cluster1"]) > 0
+    error_message = "Invalid scope name"
+  }
+
+  assert {
+    condition     = length([for scope in mongodbatlas_database_user.dbuser["user1"].scopes : scope if scope.type == "CLUSTER"]) > 0
+    error_message = "Invalid scope type"
+  }
+
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.analytics_specs.0.node_count == 3
+    error_message = "Invalid analytics node count"
+  }
 }

--- a/tests/atlas_basic_empty.tftest.hcl
+++ b/tests/atlas_basic_empty.tftest.hcl
@@ -33,4 +33,14 @@ run "atlas_basic_empty" {
     condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M10"
     error_message = "Invalid instance size"
   }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["defaultUser"].roles : role if role.role_name == "atlasAdmin"]) > 0
+    error_message = "Invalid user role"
+  }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["defaultUser"].roles : role if role.database_name == "admin"]) > 0
+    error_message = "Invalid user database"
+  }
 }

--- a/tests/atlas_basic_empty.tftest.hcl
+++ b/tests/atlas_basic_empty.tftest.hcl
@@ -1,0 +1,36 @@
+provider "mongodbatlas" {
+}
+
+run "generate_random_name" {
+    module {
+        source = "./tests/random_name_generator"
+    }
+}
+
+run "atlas_basic_empty" {
+    command = apply
+
+    module {
+        source = "./"
+    }
+
+    assert {
+        condition = mongodbatlas_project.project.name == "terraform-mongodbatlas-atlas-basic"
+        error_message = "Invalid project name"
+    }
+
+    assert {
+        condition = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
+        error_message = "Invalid database username"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.name == "Cluster0"
+        error_message = "Invalid cluster name"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M10"
+        error_message = "Invalid instance size"
+    }
+}

--- a/tests/atlas_basic_empty.tftest.hcl
+++ b/tests/atlas_basic_empty.tftest.hcl
@@ -2,35 +2,35 @@ provider "mongodbatlas" {
 }
 
 run "generate_random_name" {
-    module {
-        source = "./tests/random_name_generator"
-    }
+  module {
+    source = "./tests/random_name_generator"
+  }
 }
 
 run "atlas_basic_empty" {
-    command = apply
+  command = apply
 
-    module {
-        source = "./"
-    }
+  module {
+    source = "./"
+  }
 
-    assert {
-        condition = mongodbatlas_project.project.name == "terraform-mongodbatlas-atlas-basic"
-        error_message = "Invalid project name"
-    }
+  assert {
+    condition     = mongodbatlas_project.project.name == "terraform-mongodbatlas-atlas-basic"
+    error_message = "Invalid project name"
+  }
 
-    assert {
-        condition = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
-        error_message = "Invalid database username"
-    }
+  assert {
+    condition     = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
+    error_message = "Invalid database username"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.name == "Cluster0"
-        error_message = "Invalid cluster name"
-    }
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.name == "Cluster0"
+    error_message = "Invalid cluster name"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M10"
-        error_message = "Invalid instance size"
-    }
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M10"
+    error_message = "Invalid instance size"
+  }
 }

--- a/tests/atlas_basic_tenant.tftest.hcl
+++ b/tests/atlas_basic_tenant.tftest.hcl
@@ -2,45 +2,45 @@ provider "mongodbatlas" {
 }
 
 run "generate_random_name" {
-    module {
-        source = "./tests/random_name_generator"
-    }
+  module {
+    source = "./tests/random_name_generator"
+  }
 }
 
 run "atlas_basic_tenant_cluster" {
-    command = apply
+  command = apply
 
-    module {
-        source = "./"
-    }
+  module {
+    source = "./"
+  }
 
-    variables {
-        project_name = "test-modules-tf-p-${run.generate_random_name.name_project}"
-        cluster_name  = "TenantCluster"
-        provider_name = "TENANT"
-        region_name   = "US_EAST_1"
-        electable_specs = {
-            instance_size = "M2"
-        }
+  variables {
+    project_name  = "test-modules-tf-p-${run.generate_random_name.name_project}"
+    cluster_name  = "TenantCluster"
+    provider_name = "TENANT"
+    region_name   = "US_EAST_1"
+    electable_specs = {
+      instance_size = "M2"
     }
+  }
 
-    assert {
-        condition = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
-        error_message = "Invalid database username"
-    }
+  assert {
+    condition     = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
+    error_message = "Invalid database username"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.name == "TenantCluster"
-        error_message = "Invalid cluster name"
-    }
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.name == "TenantCluster"
+    error_message = "Invalid cluster name"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M2"
-        error_message = "Invalid instance size"
-    }
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M2"
+    error_message = "Invalid instance size"
+  }
 
-    assert {
-        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.backing_provider_name == "AWS"
-        error_message = "Invalid backing provider"
-    }
+  assert {
+    condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.backing_provider_name == "AWS"
+    error_message = "Invalid backing provider"
+  }
 }

--- a/tests/atlas_basic_tenant.tftest.hcl
+++ b/tests/atlas_basic_tenant.tftest.hcl
@@ -43,4 +43,14 @@ run "atlas_basic_tenant_cluster" {
     condition     = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.backing_provider_name == "AWS"
     error_message = "Invalid backing provider"
   }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["defaultUser"].roles : role if role.role_name == "atlasAdmin"]) > 0
+    error_message = "Invalid user role"
+  }
+
+  assert {
+    condition     = length([for role in mongodbatlas_database_user.dbuser["defaultUser"].roles : role if role.database_name == "admin"]) > 0
+    error_message = "Invalid user database"
+  }
 }

--- a/tests/atlas_basic_tenant.tftest.hcl
+++ b/tests/atlas_basic_tenant.tftest.hcl
@@ -1,0 +1,46 @@
+provider "mongodbatlas" {
+}
+
+run "generate_random_name" {
+    module {
+        source = "./tests/random_name_generator"
+    }
+}
+
+run "atlas_basic_tenant_cluster" {
+    command = apply
+
+    module {
+        source = "./"
+    }
+
+    variables {
+        project_name = "test-modules-tf-p-${run.generate_random_name.name_project}"
+        cluster_name  = "TenantCluster"
+        provider_name = "TENANT"
+        region_name   = "US_EAST_1"
+        electable_specs = {
+            instance_size = "M2"
+        }
+    }
+
+    assert {
+        condition = mongodbatlas_database_user.dbuser["defaultUser"].username == "defaultUser"
+        error_message = "Invalid database username"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.name == "TenantCluster"
+        error_message = "Invalid cluster name"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.electable_specs.0.instance_size == "M2"
+        error_message = "Invalid instance size"
+    }
+
+    assert {
+        condition = mongodbatlas_advanced_cluster.cluster.replication_specs.0.region_configs.0.backing_provider_name == "AWS"
+        error_message = "Invalid backing provider"
+    }
+}

--- a/tests/random_name_generator/main.tf
+++ b/tests/random_name_generator/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.2"
+    }
+  }
+}
+
+resource "random_string" "name_project" {
+  keepers = {
+    first = "${timestamp()}"
+  }
+  length = 16
+  special = false
+  numeric = false
+}
+
+output "name_project" {
+  value = random_string.name_project.id
+}

--- a/tests/random_name_generator/main.tf
+++ b/tests/random_name_generator/main.tf
@@ -11,7 +11,7 @@ resource "random_string" "name_project" {
   keepers = {
     first = "${timestamp()}"
   }
-  length = 16
+  length  = 16
   special = false
   numeric = false
 }


### PR DESCRIPTION
## Description
This PR contains the local tests for the atlas-basic module, as well as a README that explains how to execute locally such tests. 
Specifically, there are 3 tests:
- atlas_basic_complete: a test where all the input variables are given
- atlas_basic_empty: a test where none of the input variables are given
- atlas_basic_tenant: a test where a TENANT cluster is created

## Important
- The tests (in total) last 30+ minutes to execute (this is because of the create cluster resource)
- The random_name_generator "submodule" has been added to generate a random project name at each test and execution